### PR TITLE
fix to_agraph error

### DIFF
--- a/pcapviz/core.py
+++ b/pcapviz/core.py
@@ -141,7 +141,7 @@ class GraphManager(object):
 
     #TODO do we need a .dot file export?
     def get_graphviz_format(self, filename=None):
-        agraph = networkx.to_agraph(self.graph)
+        agraph = networkx.drawing.nx_agraph.to_agraph(self.graph)
         if filename:
             agraph.write(filename)
         return agraph


### PR DESCRIPTION
fix the "AttributeError: 'module' object has no attribute 'to_agraph'" error by replacing "agraph = networkx.to_agraph(self.graph)" with "agraph = networkx.drawing.nx_agraph.to_agraph(self.graph)"
@mateuszk87 
