### PR TITLE
Update scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scapy-python3
+scapy>=2.4.0
 matplotlib
 networkx
 pygeoip


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3