### PR TITLE
add dpi argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ parser.add_argument('-l', '--geolang', default='en', help='Language to use for g
 parser.add_argument('-E', '--layoutengine', default='sfdp', help='Graph layout method - dot, sfdp etc.')
 parser.add_argument('-s', '--shape', default='diamond', help='Graphviz node shape - circle, diamond, box etc.')
 parser.add_argument('-n', '--nmax', default=100, help='Automagically draw individual protocols where useful if more than --nmax nodes. 100 seems too many for any one graph.')
+parser.add_argument('--dpi', default=96, help='DPI for graph output image (default: 96)')
 
 args = parser.parse_args()
 

--- a/pcapviz/core.py
+++ b/pcapviz/core.py
@@ -160,6 +160,7 @@ class GraphManager(object):
 		self.graph.label ="Layer %d traffic graph for packets from %s" % (self.layer,str(self.args.pcaps))
 
 		graph = self.get_graphviz_format()
+		graph.graph_attr['dpi'] = self.args.dpi
 		
 		for node in graph.nodes():
 			if node not in self.data:


### PR DESCRIPTION
For some large network graphs the resolution of the resulting `.png` file was a bit rough. I added the `--dpi` argument to fix this. The default is 96, just like `pygraphviz` has.